### PR TITLE
add proxy settings for AppaloosaClient

### DIFF
--- a/src/main/groovy/com/octo/nicolasmouchel/AppaloosaDeployPlugin.groovy
+++ b/src/main/groovy/com/octo/nicolasmouchel/AppaloosaDeployPlugin.groovy
@@ -1,21 +1,37 @@
 package com.octo.nicolasmouchel
 
+import com.appaloosastore.client.AppaloosaClient
 import org.gradle.api.Plugin
 import org.gradle.api.Project
-import com.appaloosastore.client.AppaloosaClient;
 
 class AppaloosaDeployPlugin implements Plugin<Project> {
+
     void apply(Project project) {
 
+        AppaloosaDeployPluginExtension extension = project.extensions.create("appaloosaDeploy", AppaloosaDeployPluginExtension)
+
         def apks = project.container(AppaloosaDeployApks)
-        AppaloosaDeployPluginExtension extension = project.extensions.create(
-                "appaloosaDeploy", AppaloosaDeployPluginExtension)
-        extension.apks = apks;
+        extension.apks = apks
 
         extension.apks.all { apk ->
             project.task("appaloosaDeploy${name.capitalize()}", group: 'Deploy') << {
                 println "--Start deploying--"
                 def client = new AppaloosaClient(extension.storeToken)
+                if (extension.proxy != null) {
+                    println "--Using proxy : " + extension.proxy
+                    if (extension.proxy.host != null) {
+                        client.setProxyHost(extension.proxy.host);
+                    }
+                    if (extension.proxy.port > 0) {
+                        client.setProxyPort(extension.proxy.port);
+                    }
+                    if (extension.proxy.user != null) {
+                        client.setProxyUser(extension.proxy.user);
+                    }
+                    if (extension.proxy.pass != null) {
+                        client.setProxyPass(extension.proxy.pass);
+                    }
+                }
                 client.deployFile(
                         project.buildDir.absolutePath + "/outputs/apk/${apk.getApkName(project.name)}",
                         descriptionVersion,

--- a/src/main/groovy/com/octo/nicolasmouchel/AppaloosaDeployPluginExtension.groovy
+++ b/src/main/groovy/com/octo/nicolasmouchel/AppaloosaDeployPluginExtension.groovy
@@ -1,5 +1,6 @@
 package com.octo.nicolasmouchel
 
+import groovy.transform.ToString
 import org.gradle.api.NamedDomainObjectContainer
 import org.gradle.api.tasks.Input
 
@@ -8,6 +9,8 @@ class AppaloosaDeployPluginExtension {
     String storeToken
     @Input
     NamedDomainObjectContainer<AppaloosaDeployApks> apks
+    @Input
+    AppaloosaDeployProxy proxy
 
     void storeToken(String storeToken) {
         this.storeToken = storeToken
@@ -15,6 +18,12 @@ class AppaloosaDeployPluginExtension {
 
     void apks(Closure closure) {
         apks.configure(closure)
+    }
+
+    void proxy(Closure closure) {
+        proxy = new AppaloosaDeployProxy()
+        closure.delegate = proxy
+        closure()
     }
 }
 
@@ -29,7 +38,9 @@ class AppaloosaDeployApks {
     AppaloosaDeployApks(String name) {
         this.name = name
     }
-String getApkName(){return ''}
+
+    String getApkName() { return '' }
+
     String getApkName(String moduleName) {
         if (apkName != null) {
             return apkName
@@ -65,5 +76,36 @@ String getApkName(){return ''}
 
     void groupsName(final String groupsName) {
         this.groupsName = groupsName
+    }
+}
+
+class AppaloosaDeployProxy {
+    String host
+    int port = 0
+    String user
+    String pass
+
+    AppaloosaDeployProxy() {
+        //
+    }
+
+    void host(final String host) {
+        this.host = host
+    }
+
+    void port(final int port) {
+        this.port = port
+    }
+
+    void user(final String user) {
+        this.user = user
+    }
+
+    void pass(final String pass) {
+        this.pass = pass
+    }
+
+    String toString() {
+        "(host:${host}, port:{port}, user:${user}, pass:${pass})"
     }
 }


### PR DESCRIPTION
Hello,

A PR to add the possibility to set the proxy settings for AppaloosaClient.

Add `proxy` section to `appaloosaDeploy` task

```
appaloosaDeploy {
    ...
    proxy {
        host 'proxy-hostname'
        port proxy-portnumber
        user 'proxy-username'
        pass 'proxy-password'
    }
    ...
}
```

Kind Regards,
Thierry
